### PR TITLE
4.2.4 + Qt6

### DIFF
--- a/com.github.rssguard.yaml
+++ b/com.github.rssguard.yaml
@@ -1,8 +1,8 @@
 id: com.github.rssguard
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 6.3
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-21.08
+base-version: 6.3
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
@@ -22,9 +22,27 @@ finish-args:
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 modules:
+  # Needed for Qt 6.
+  # See also: https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/26
+  - name: qt6-core5compat
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://download.qt.io/official_releases/qt/6.3/6.3.1/submodules/qt5compat-everywhere-src-6.3.1.tar.xz
+        sha256: a43ec62bd778eaecf88ad7847118d1c2a471b0fcb820f93beb311d7ab9566cfd
+        x-checker-data:
+          type: html
+          url: https://download.qt.io/official_releases/qt/6.3/
+          version-pattern: '>([\d\.-]*)/<'
+          url-template: https://download.qt.io/official_releases/qt/6.3/$version/submodules/qt5compat-everywhere-src-$version.tar.xz
+    post-install:
+      - ln -sr /app/lib/${FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so* -t /app/lib
+
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:
+      - -DBUILD_WITH_QT6=ON
       - -DNO_UPDATE_CHECK=ON
       - -DIS_FLATPAK_BUILD=ON
     sources:
@@ -35,6 +53,7 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
+
   - name: nodejs_and_npm
     buildsystem: simple
     build-commands:

--- a/com.github.rssguard.yaml
+++ b/com.github.rssguard.yaml
@@ -48,8 +48,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/martinrotter/rssguard.git
-        tag: 4.2.3
-        commit: 68c03688bf52b2122a25cc813dfafeff7c1fca28
+        tag: 4.2.4
+        commit: 1f6d7c0bf429c93e6c5b0c2f018a0da509bc1a39
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
I just want to test if this fixes https://github.com/martinrotter/rssguard/issues/565, once and for all.

My current setup:

- Arch Linux
- GNOME 42.4
- RSS Guard 4.2.3 (built with Qt 5.15.4)

Currently, there doesn't seem to leak file descriptors as badly as before (presumably caused by just calling `QSystemTrayIcon::isSystemTrayAvailable()`), so that's good.

However, there is this other horrible leak triggered by just hovering links in the WebView (caused by `QWebEngineView::setHtml()`?):


https://user-images.githubusercontent.com/626206/187040448-aa6c0841-9177-4783-b56e-db482bc92b49.mp4

The commands I used in the video:

- `flatpak run com.github.rssguard -w` (to launch RSS Guard with "basic" WebView support)
- `watch -n.1 'bash -c "echo fd count: ±$(ls -l /proc/$(pidof rssguard)/fd | wc -l)"'` (to monitor fd count)

However, I've been experimenting with [Arch Linux's official build](https://archlinux.org/packages/community/x86_64/rssguard/) of RSS Guard, which only recently switched to building with Qt 6. From my testing, the same fd leak above *does not* happen in the Qt 6 build, so I want to see if this hopefully fixes the Flatpak package as well!

Closes #31