### PR TITLE
App id was renamed, this is now 'end of life'

### DIFF
--- a/com.github.rssguard.yaml
+++ b/com.github.rssguard.yaml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
-  - --filesystem=xdg-config/autostart:create
   - --filesystem=xdg-download
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to io.github.martinrotter.rssguard.",
+  "end-of-life-rebase": "io.github.martinrotter.rssguard"
+}


### PR DESCRIPTION
We're now at https://github.com/flathub/io.github.martinrotter.rssguard.